### PR TITLE
Add pandas version to environment.yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: env_transport
 dependencies:
     - python=3.10
     - pypsa=0.22.1
+    - pandas>=1.5.3
     - snakemake-minimal
     - gurobi
 


### PR DESCRIPTION
To avoid issues in the plotting script, potentially caused by differences in versions of Pandas, I have added a definition of the Pandas version used to produce the plots to the environment.yaml. 